### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,26 @@
 
 **Authors:** Schnepp et al.
 
-**Journal:** Physics of the Earth and Planetary Interiors
+**Journal:** Physics of the Earth and Planetary Interiors, 2020
 
 ## Data description:
 
-please add some basic description of data format and contents
+This repository contains all raw data used in the above publication.
 
+Thellier-Thellier.zip: Each subdirectory corresponds to a site and contains data of Thellier and Thellier (1959) experiments in the ThellierTool4.0 format (Leonhardt et al. 2004).
+
+Coe-Thellier.zip: Each subdirectory corresponds to a site and contains data of Thellier experiments performed in Coe (1967) version in ThellierTool4.0 format (Leonhardt et al. 2004).
+
+MSP-DSC.zip: Each file contains data of the multiple-specimen domain-state corrected (MSP-DSC) version (Fabian and Leonhardt, 2010) for one site. Data format is compatible with the Python tool (https://github.com/leonro/MSPTool) which can be used for analysis.
+
+Name of the subdirectories/files correspond to Table 1 of the publication, column 5. 
+
+References
+
+Coe, R. S., 1967. Palaeointensity of the Earth’s magnetic field determined from tertiary and quaternary rocks, J. Geophys. Res. 72, 3247– 3262.
+
+Fabian, K., Leonhardt, R., 2010. Multiple-specimen absolute paleointensity determination: An optimal protocol including pTRM normalization, domain-state correction, and alteration test. Earth Planet. Sci. Lett. 297, 84–94.
+
+Leonhardt, R., Heunemann, C., Krása, D. 2004. Analyzing absolute paleointensity determinations: Acceptance criteria and the software ThellierTool4.0. Geochem. Geophys. Geosys., 5(12).
+
+Thellier, E., O. Thellier (1959), Sur l’intensité du champ magnétique terrestre dans le passé historique et géologique, Ann. Géophys. 15, 285– 376.


### PR DESCRIPTION
**Journal:** Physics of the Earth and Planetary Interiors, 2020

## Data description:

This repository contains all raw data used in the above publication.

Thellier-Thellier.zip: Each subdirectory corresponds to a site and contains data of Thellier and Thellier (1959) experiments in the ThellierTool4.0 format (Leonhardt et al. 2004).

Coe-Thellier.zip: Each subdirectory corresponds to a site and contains data of Thellier experiments performed in Coe (1967) version in ThellierTool4.0 format (Leonhardt et al. 2004).

MSP-DSC.zip: Each file contains data of the multiple-specimen domain-state corrected (MSP-DSC) version (Fabian and Leonhardt, 2010) for one site. Data format is compatible with the Python tool (https://github.com/leonro/MSPTool) which can be used for analysis.

Name of the subdirectories/files correspond to Table 1 of the publication, column 5. 

References

Coe, R. S., 1967. Palaeointensity of the Earth’s magnetic field determined from tertiary and quaternary rocks, J. Geophys. Res. 72, 3247– 3262.

Fabian, K., Leonhardt, R., 2010. Multiple-specimen absolute paleointensity determination: An optimal protocol including pTRM normalization, domain-state correction, and alteration test. Earth Planet. Sci. Lett. 297, 84–94.

Leonhardt, R., Heunemann, C., Krása, D. 2004. Analyzing absolute paleointensity determinations: Acceptance criteria and the software ThellierTool4.0. Geochem. Geophys. Geosys., 5(12).

Thellier, E., O. Thellier (1959), Sur l’intensité du champ magnétique terrestre dans le passé historique et géologique, Ann. Géophys. 15, 285– 376.